### PR TITLE
Add module initializer for hooking up assembly prefixes to exclude

### DIFF
--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -43,20 +43,6 @@ public static class HostBuilderExtensions
 
         builder.ConfigureAppConfiguration((context, config) => config.AddJsonFile(Path.Combine("./config", "appsettings.json"), optional: true, reloadOnChange: true));
 
-        PackageReferencedAssemblies.Instance.AddAssemblyPrefixesToExclude(
-            "AutoMapper",
-            "Autofac",
-            "Azure",
-            "Elasticsearch",
-            "FluentValidation",
-            "Grpc",
-            "Handlebars",
-            "NJsonSchema",
-            "MongoDB",
-            "Orleans",
-            "Serilog",
-            "Swashbuckle");
-
         Internals.Types = Types.Instance;
         Internals.Types.RegisterTypeConvertersForConcepts();
         TypeConverters.Register();

--- a/Source/DotNET/Applications/ModuleInitializer.cs
+++ b/Source/DotNET/Applications/ModuleInitializer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Aksio.Types;
+
+namespace Microsoft.Extensions.Hosting;
+
+#pragma warning disable CA2255 // Allow module initializer
+
+/// <summary>
+/// Module initializer for the Application Model.
+/// </summary>
+internal static class ModuleInitializer
+{
+    /// <summary>
+    /// Initializes the module.
+    /// </summary>
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        PackageReferencedAssemblies.Instance.AddAssemblyPrefixesToExclude(
+            "AutoMapper",
+            "Autofac",
+            "Azure",
+            "Elasticsearch",
+            "FluentValidation",
+            "Grpc",
+            "Handlebars",
+            "NJsonSchema",
+            "MongoDB",
+            "Orleans",
+            "Serilog",
+            "Swashbuckle");
+    }
+}


### PR DESCRIPTION
### Fixed

- Adding a `ModuleInitializer` to perform all the exclusion of assemblies for the type discovery system.
