### PR TITLE
Fixing merge error

### DIFF
--- a/Source/DotNET/CQRS/Queries/ClientObservable.cs
+++ b/Source/DotNET/CQRS/Queries/ClientObservable.cs
@@ -63,8 +63,6 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
                 subscription?.Dispose();
                 ClientDisconnected?.Invoke();
             }
-
-            await webSocket.SendAsync(new ArraySegment<byte>(message, 0, message.Length), WebSocketMessageType.Text, true, CancellationToken.None);
         });
 
         var buffer = new byte[1024 * 4];


### PR DESCRIPTION
### Fixed

- Fixed null reference exception for duplicate `SendAsync` call caused by an error during merging.
