### PR TITLE
Remove UseWebSockets() - as this needs to be controlled by the apps themselves

### DIFF
--- a/Source/DotNET/Applications/ApplicationBuilderExtensions.cs
+++ b/Source/DotNET/Applications/ApplicationBuilderExtensions.cs
@@ -23,7 +23,6 @@ public static class ApplicationBuilderExtensions
         app.UseExecutionContext();
 
         app.UseResponseCompression();
-        app.UseWebSockets();
         app.UseDefaultFiles();
         app.UseStaticFiles();
 


### PR DESCRIPTION
### Fixed

- Removing `.UseWebSockets()` call from the `.UseAksio()` extension method, as this needs to be explicitly called from the applications themselves in the right order.
