### PR TITLE
Adding trace logging for seeing WebSocket info

### DIFF
--- a/Source/DotNET/CQRS/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/CQRS/Queries/QueryActionFilter.cs
@@ -164,6 +164,11 @@ public class QueryActionFilter : IAsyncActionFilter
     /// </remarks>
     void HandleWebSocketHeadersForMultipleProxies(HttpContext httpContext)
     {
+        _logger.DumpWebSocketHeaders(
+            httpContext.Request.Headers.SecWebSocketProtocol.ToString(),
+            httpContext.Request.Headers.SecWebSocketExtensions.ToString(),
+            httpContext.Request.Headers.SecWebSocketVersion.ToString(),
+            httpContext.Request.Headers.SecWebSocketKey.ToString());
         var keys = httpContext.Request.Headers.SecWebSocketKey.ToString().Split(',').Select(_ => _.Trim()).ToArray();
         if (keys.Length > 1)
         {

--- a/Source/DotNET/CQRS/Queries/QueryActionFilterLogMessages.cs
+++ b/Source/DotNET/CQRS/Queries/QueryActionFilterLogMessages.cs
@@ -21,4 +21,7 @@ internal static partial class QueryActionFilterLogMessages
 
     [LoggerMessage(3, LogLevel.Trace, "Controller {Controller} with action {Action} returns a regular object")]
     internal static partial void NonClientObservableReturnValue(this ILogger<QueryActionFilter> logger, string controller, string action);
+
+    [LoggerMessage(4, LogLevel.Trace, "WebSocket headers are as follows: Protocol='{Protocol}' Extensions='{Extensions}' Version='{Version}' Key='{Key}'")]
+    internal static partial void DumpWebSocketHeaders(this ILogger<QueryActionFilter> logger, string protocol, string extensions, string version, string key);
 }


### PR DESCRIPTION
### Fixed

- Adding trace logging for seeing WebSocket HTTP headers for debugging purposes.
