### PR TITLE
Fix/proxygenerator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ],
+    "compounds": [
+    ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Aksio.Defaults" Version="1.6.10" />
 		<PackageVersion Include="Aksio.Defaults.Specs" Version="1.6.10" />
-		<PackageVersion Include="Aksio.Fundamentals" Version="1.3.10" />
+		<PackageVersion Include="Aksio.Fundamentals" Version="1.4.2" />
         <PackageVersion Include="Autofac" Version="6.4.0" />
         <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />

--- a/Source/DotNET/Serilog/ExecutionContextLogEnricher.cs
+++ b/Source/DotNET/Serilog/ExecutionContextLogEnricher.cs
@@ -27,16 +27,6 @@ public class ExecutionContextLogEnricher : ILogEventEnricher
     /// </summary>
     public const string CorrelationIdProperty = "CorrelationId";
 
-    /// <summary>
-    /// The name of the property for the causation identifier.
-    /// </summary>
-    public const string CausationIdProperty = "CausationId";
-
-    /// <summary>
-    /// The name of the property for the caused by identifier.
-    /// </summary>
-    public const string CausedByIdProperty = "CausedById";
-
     /// <inheritdoc/>
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
@@ -45,8 +35,6 @@ public class ExecutionContextLogEnricher : ILogEventEnricher
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(MicroserviceIdProperty, ExecutionContextManager.GetCurrent().MicroserviceId.Value));
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(TenantIdProperty, ExecutionContextManager.GetCurrent().TenantId.Value));
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CorrelationIdProperty, ExecutionContextManager.GetCurrent().CorrelationId.Value));
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CausationIdProperty, ExecutionContextManager.GetCurrent().CausationId.Value));
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CausedByIdProperty, ExecutionContextManager.GetCurrent().CausedBy.Value));
         }
     }
 }


### PR DESCRIPTION
### Fixed

- Fixing proxy generator to sanitize paths for commands and queries to avoid multiple forward slashes. This improves import statements by removing unnecessary additional navigation.
- Fixing a bug in the proxy generator when types had reference to itself, it mistaked this as a potential type conflict.
