### PR TITLE
Await the result of the query on refresh

### DIFF
--- a/Source/JavaScript/Applications/queries/useQuery.ts
+++ b/Source/JavaScript/Applications/queries/useQuery.ts
@@ -34,6 +34,6 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
 
     return [result, async (args?: TArguments) => {
         setResult(QueryResultWithState.fromQueryResult(result, true));
-        queryExecutor(args);
+        await queryExecutor(args);
     }];
 }


### PR DESCRIPTION
### Fixed

- Await the result of the query when doing a refresh. The operation is async.
