### PR TITLE
Fix/proxygenerator

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Aksio.Defaults" Version="1.6.10" />
 		<PackageVersion Include="Aksio.Defaults.Specs" Version="1.6.10" />
-		<PackageVersion Include="Aksio.Fundamentals" Version="1.4.2" />
+		<PackageVersion Include="Aksio.Fundamentals" Version="1.5.0" />
         <PackageVersion Include="Autofac" Version="6.4.0" />
         <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />

--- a/Source/DotNET/ProxyGenerator/Diagnostics.cs
+++ b/Source/DotNET/ProxyGenerator/Diagnostics.cs
@@ -50,6 +50,19 @@ public static class Diagnostics
         default);
 
     /// <summary>
+    /// The <see cref="Diagnostic"/> to report when key in dictionary is not string.
+    /// </summary>
+    public static readonly Func<string, Diagnostic> KeyOfDictionaryMustBeString = (string typeName) => Diagnostic.Create(
+        new DiagnosticDescriptor(
+            "AKSIO0005",
+            "The type of the key in the dictionary must be string",
+            $"The type '{typeName}' must have string as key for the dictionary. Only strings are supported as this maps directly to an object literal.",
+            "Generation",
+            DiagnosticSeverity.Error,
+            true),
+        default);
+
+    /// <summary>
     /// The <see cref="Diagnostic"/> to report when the output path is missing.
     /// </summary>
     /// <param name="exception">The exception that occurred.</param>

--- a/Source/DotNET/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
+++ b/Source/DotNET/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
@@ -174,7 +174,7 @@ public static class TypeSymbolExtensions
     public static bool IsDictionary(this ITypeSymbol symbol)
     {
         if (symbol.IsKnownType()) return false;
-        bool isDictionary(ITypeSymbol symbol) => symbol.ToDisplayString().StartsWith("System.Collections.Generic.IDictionary");
+        static bool isDictionary(ITypeSymbol symbol) => symbol.ToDisplayString().StartsWith("System.Collections.Generic.IDictionary");
         if (isDictionary(symbol)) return true;
         return symbol.AllInterfaces.Any(isDictionary);
     }

--- a/Source/DotNET/ProxyGenerator/Templates/PropertyDescriptor.cs
+++ b/Source/DotNET/ProxyGenerator/Templates/PropertyDescriptor.cs
@@ -13,4 +13,11 @@ namespace Aksio.Applications.ProxyGenerator.Templates;
 /// <param name="IsNullable">Whether or not the property is nullable or not.</param>
 /// <param name="HasDerivatives">Whether or not the property type has derivatives, typically if it is an interface type.</param>
 /// <param name="Derivatives">Optionally any derivatives of the type.</param>
-public record PropertyDescriptor(string Name, string Type, string Constructor, bool IsEnumerable, bool IsNullable, bool HasDerivatives, IEnumerable<string>? Derivatives = default);
+public record PropertyDescriptor(
+    string Name,
+    string Type,
+    string Constructor,
+    bool IsEnumerable,
+    bool IsNullable,
+    bool HasDerivatives,
+    IEnumerable<string>? Derivatives = default);

--- a/Source/DotNET/ProxyGenerator/Templates/RequestArgumentDescriptor.cs
+++ b/Source/DotNET/ProxyGenerator/Templates/RequestArgumentDescriptor.cs
@@ -4,7 +4,7 @@
 namespace Aksio.Applications.ProxyGenerator.Templates;
 
 /// <summary>
-/// Describes a query argument for templating purposes.
+/// Describes a query argument for template purposes.
 /// </summary>
 /// <param name="Name">Name of argument.</param>
 /// <param name="Type">Type of argument.</param>

--- a/Source/JavaScript/Applications/package.json
+++ b/Source/JavaScript/Applications/package.json
@@ -61,8 +61,8 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@aksio/fundamentals": "1.0.10",
-        "@aksio/typescript": "1.0.10",
+        "@aksio/fundamentals": "1.5.0",
+        "@aksio/typescript": "1.5.0",
         "handlebars": "4.7.7"
     }
 }


### PR DESCRIPTION
### Fixed

- Fixing so that dictionary types are outputted as object literals with type definition for key & value (supports only string keys) in proxy generator.
- Fixing so that types can properties of type referencing themselves - recursiveness.
