### PR TITLE
Proxy generator will now ignore AspNetResult commands and queries

### DIFF
--- a/Documentation/cqrs/without-wrappers.md
+++ b/Documentation/cqrs/without-wrappers.md
@@ -55,3 +55,8 @@ public class Accounts : Controller
     }
 }
 ```
+
+## Proxy generator
+
+The proxy generator will exclude commands or queries that are marked with the `[AspNetResult]`
+attribute and as a consequence not generate any artifacts for the affect command or query.

--- a/Source/DotNET/ProxyGenerator/SourceGenerator.cs
+++ b/Source/DotNET/ProxyGenerator/SourceGenerator.cs
@@ -68,6 +68,8 @@ public class SourceGenerator : ISourceGenerator
                     rootNamespace = type.ContainingAssembly.Name!;
                 }
 
+                if (type.GetAttributes().Any(_ => _.IsAspNetResultAttribute())) continue;
+
                 var routeAttribute = type.GetRouteAttribute();
                 if (routeAttribute == default) return;
 
@@ -90,7 +92,7 @@ public class SourceGenerator : ISourceGenerator
         var targetFolder = GetTargetFolder(type, rootNamespace, outputFolder, useRouteAsPath, baseApiRoute);
         var generatedTypes = new List<ITypeSymbol>();
 
-        foreach (var commandMethod in methods.Where(_ => _.GetAttributes().Any(_ => _.IsHttpPostAttribute())))
+        foreach (var commandMethod in methods.Where(_ => _.IsCommandMethod()))
         {
             var route = GetRoute(baseApiRoute, commandMethod);
             var properties = new List<PropertyDescriptor>();
@@ -174,7 +176,7 @@ public class SourceGenerator : ISourceGenerator
         var targetFolder = GetTargetFolder(type, rootNamespace, outputFolder, useRouteAsPath, baseApiRoute);
         var generatedTypes = new List<ITypeSymbol>();
 
-        foreach (var queryMethod in methods.Where(_ => _.GetAttributes().Any(_ => _.IsHttpGetAttribute())))
+        foreach (var queryMethod in methods.Where(_ => _.IsQueryMethod()))
         {
             var modelType = queryMethod.ReturnType;
 

--- a/Source/DotNET/ProxyGenerator/Syntax/MethodSymbolExtensions.cs
+++ b/Source/DotNET/ProxyGenerator/Syntax/MethodSymbolExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Aksio.Applications.ProxyGenerator.Syntax;
+
+/// <summary>
+/// Extension methods for working with <see cref="IMethodSymbol"/>.
+/// </summary>
+public static class MethodSymbolExtensions
+{
+    /// <summary>
+    /// Check if a method if a command method.
+    /// </summary>
+    /// <param name="method">Method to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsCommandMethod(this IMethodSymbol method) =>
+        method.GetAttributes().Any(_ => _.IsHttpPostAttribute()) &&
+        !method.GetAttributes().Any(_ => _.IsAspNetResultAttribute());
+
+    /// <summary>
+    /// Check if a method if a command method.
+    /// </summary>
+    /// <param name="method">Method to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsQueryMethod(this IMethodSymbol method) =>
+        method.GetAttributes().Any(_ => _.IsHttpGetAttribute()) &&
+        !method.GetAttributes().Any(_ => _.IsAspNetResultAttribute());
+}

--- a/Source/DotNET/ProxyGenerator/Syntax/WellKnownAttributeExtensions.cs
+++ b/Source/DotNET/ProxyGenerator/Syntax/WellKnownAttributeExtensions.cs
@@ -16,6 +16,7 @@ public static class WellKnownAttributeExtensions
     const string FromQueryAttribute = "Microsoft.AspNetCore.Mvc.FromQueryAttribute";
     const string RouteAttribute = "Microsoft.AspNetCore.Mvc.RouteAttribute";
     const string DerivedTypeAttribute = "Aksio.Serialization.DerivedTypeAttribute";
+    const string AspNetResultAttribute = "Aksio.Applications.AspNetResultAttribute";
 
     /// <summary>
     /// Get the route attribute - if any.
@@ -102,4 +103,11 @@ public static class WellKnownAttributeExtensions
     /// <param name="symbol">Symbol to check.</param>
     /// <returns>True if it is, false if not.</returns>
     public static bool IsDerivedTypeAttribute(this AttributeData symbol) => symbol.AttributeClass?.ToString() == DerivedTypeAttribute;
+
+    /// <summary>
+    /// Check whether or not a symbol is an AspNetResultAttribute.
+    /// </summary>
+    /// <param name="symbol">Symbol to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsAspNetResultAttribute(this AttributeData symbol) => symbol.AttributeClass?.ToString() == AspNetResultAttribute;
 }


### PR DESCRIPTION
### Fixed

- Proxy generator will now ignore any ASP.NET controller actions marked with `[AspNetResult]` attribute, as intended.
