### PR TITLE
Changing to discover assemblies with implementations of ControllerBase in it, not just Controller

### DIFF
--- a/Source/DotNET/Applications/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton(Globals.JsonSerializerOptions!);
 
-        foreach (var controllerAssembly in ProjectReferencedAssemblies.Instance.Assemblies.Where(_ => _.DefinedTypes.Any(type => type.Implements(typeof(Controller)))))
+        foreach (var controllerAssembly in ProjectReferencedAssemblies.Instance.Assemblies.Where(_ => _.DefinedTypes.Any(type => type.Implements(typeof(ControllerBase)))))
         {
             controllerBuilder.PartManager.ApplicationParts.Add(new AssemblyPart(controllerAssembly));
         }


### PR DESCRIPTION
### Fixed

- Changed the automatic hookup of assembly parts that holds controllers to discover based on implementations of `ControllerBase` and not `Controller`, which is more accurate as pure API controllers should inherit from `ControllerBase`.
