### PR TITLE
Make sure we never return an object literal for something that is an array

### DIFF
--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -48,6 +48,8 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
                 if (this.enumerable) {
                     if (Array.isArray(result.data)) {
                         result.data = JsonSerializer.deserializeArrayFromInstance(this.modelType, result.data);
+                    } else {
+                        result.data = [];
                     }
                 } else {
                     result.data = JsonSerializer.deserializeFromInstance(this.modelType, result.data);

--- a/Source/JavaScript/Applications/queries/QueryResult.ts
+++ b/Source/JavaScript/Applications/queries/QueryResult.ts
@@ -58,7 +58,11 @@ export class QueryResult<TDataType = {}> implements IQueryResult<TDataType> {
         if (result.data) {
             let data: any = result.data;
             if (enumerable) {
-                data = JsonSerializer.deserializeArrayFromInstance(instanceType, data);
+                if (Array.isArray(result.data)) {
+                    data = JsonSerializer.deserializeArrayFromInstance(instanceType, data);
+                } else {
+                    data = [];
+                }
             } else {
                 data = JsonSerializer.deserializeFromInstance(instanceType, data);
             }


### PR DESCRIPTION
### Fixed

- Fixed `ObservableQueryFor` and `QueryFor` for frontend to make sure it returns an array for enumerable types, even if the server returns an object. It will set it to an empty array if that is the case. That way it is consistently the correct type at least.
