### PR TITLE
Change to not actually resolve the IProvideIdentityDetails service, a…

### DIFF
--- a/Source/DotNET/Applications/Identity/IdentityProviderEndpointExtensions.cs
+++ b/Source/DotNET/Applications/Identity/IdentityProviderEndpointExtensions.cs
@@ -42,11 +42,13 @@ public static class IdentityProviderEndpointExtensions
     /// <exception cref="MultipleIdentityDetailsProvidersFound">Thrown if multiple identity details providers are found.</exception>
     public static IEndpointRouteBuilder MapIdentityProvider(this IEndpointRouteBuilder endpoints, IApplicationBuilder app)
     {
-        var identityProvider = app.ApplicationServices.GetService<IProvideIdentityDetails>();
-        if (identityProvider is not null)
+        var serviceProviderIsService = app.ApplicationServices.GetService<IServiceProviderIsService>();
+        if (serviceProviderIsService!.IsService(typeof(IProvideIdentityDetails)))
         {
-            endpoints.MapGet(".aksio/me", async (HttpRequest request, HttpResponse response) =>
-                await app.ApplicationServices.GetService<IdentityProviderEndpoint>()!.Handler(request, response));
+            endpoints.MapGet(
+                ".aksio/me",
+                (HttpRequest request, HttpResponse response) =>
+                    app.ApplicationServices.GetService<IdentityProviderEndpoint>()!.Handler(request, response));
         }
 
         return endpoints;

--- a/Specifications/Applications/Identity/for_IdentityProviderEndpoint/given/a_valid_identity_request.cs
+++ b/Specifications/Applications/Identity/for_IdentityProviderEndpoint/given/a_valid_identity_request.cs
@@ -28,7 +28,7 @@ public abstract class a_valid_identity_request : an_identity_provider_endpoint
             return Task.FromResult(details_result);
         });
     }
-    
+
     protected virtual ClientPrincipal CreateClientPrincipal()
     {
         return new()


### PR DESCRIPTION
### Fixed

- 1.3.1 broke startup for projects that implemented IProvideIdentityDetails, by resolving the service during startup - before it was ready.
- This fixes that by instead using IServiceProviderIsService.IsService() to only determine if a IProvideIdentityDetails has been registered.