### PR TITLE
Fix for crash that occured when no identity providers are present

### DIFF
--- a/Source/DotNET/Applications/Identity/IdentityProviderEndpointExtensions.cs
+++ b/Source/DotNET/Applications/Identity/IdentityProviderEndpointExtensions.cs
@@ -28,7 +28,11 @@ public static class IdentityProviderEndpointExtensions
         {
             throw new MultipleIdentityDetailsProvidersFound(providerTypes);
         }
-        services.AddSingleton(typeof(IProvideIdentityDetails), providerTypes[0]!);
+
+        if (providerTypes.Length == 1)
+        {
+            services.AddSingleton(typeof(IProvideIdentityDetails), providerTypes[0]);
+        }
 
         return services;
     }

--- a/Specifications/Applications/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_no_providers.cs
+++ b/Specifications/Applications/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_no_providers.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aksio.Applications.Identity.for_IdentityProviderEndpointExtensions.when_adding_identity_provider;
+
+public class and_there_are_no_providers : Specification
+{
+    Mock<IServiceCollection> services;
+    Mock<ITypes> types;
+
+    void Establish()
+    {
+        services = new();
+        types = new();
+    }
+
+    void Because() => services.Object.AddIdentityProvider(types.Object);
+
+    [Fact] void should_not_add_service_registration() => services.Verify(_ => _.Add(IsAny<ServiceDescriptor>()), Never);
+}


### PR DESCRIPTION
### Fixed

- The previous version crashed on startup if used in a solution without an identity provider.

