### PR TITLE
Making the callback for subscribe generic to get the actual data type

### DIFF
--- a/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
@@ -3,11 +3,12 @@
 
 import Handlebars from 'handlebars';
 import { ObservableQuerySubscription } from './ObservableQuerySubscription';
+import { QueryResult } from './QueryResult';
 
 /**
  * The delegate type representing the callback of result from the server.
  */
-export type OnNextResult = <TDataType>(data: TDataType) => void;
+export type OnNextResult<TDataType> = (data: TDataType) => void;
 
 /**
  * Defines the base of a query.
@@ -26,5 +27,5 @@ export interface IObservableQueryFor<TDataType, TArguments = {}> {
      * @param [args] Optional arguments for the query - depends on whether or not the query needs arguments.
      * @returns {ObservableQuerySubscription<TDataType>}.
      */
-    subscribe(callback: OnNextResult, args?: TArguments): ObservableQuerySubscription<TDataType>;
+    subscribe(callback: OnNextResult<QueryResult<TDataType>>, args?: TArguments): ObservableQuerySubscription<TDataType>;
 }

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -10,6 +10,7 @@ import { IObservableQueryConnection } from './IObservableQueryConnection';
 import { NullObservableQueryConnection } from './NullObservableQueryConnection';
 import { Constructor } from '@aksio/fundamentals';
 import { JsonSerializer } from '@aksio/fundamentals';
+import { QueryResult } from './QueryResult';
 
 /**
  * Represents an implementation of {@link IQueryFor}.
@@ -30,7 +31,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
     }
 
     /** @inheritdoc */
-    subscribe(callback: OnNextResult, args?: TArguments): ObservableQuerySubscription<TDataType> {
+    subscribe(callback: OnNextResult<QueryResult<TDataType>>, args?: TArguments): ObservableQuerySubscription<TDataType> {
         let actualRoute = this.route;
         let connection: IObservableQueryConnection<TDataType>;
 

--- a/Source/JavaScript/Applications/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications/queries/useObservableQuery.ts
@@ -21,8 +21,7 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
     const argumentsDependency = queryInstance.requestArguments.map(_ => args?.[_]);
 
     useEffect(() => {
-        const subscription = queryInstance.subscribe(_ => {
-            const response = _ as unknown as QueryResult<TDataType>;
+        const subscription = queryInstance.subscribe(response => {
             setResult(QueryResultWithState.fromQueryResult(response, false));
         }, args as any);
 


### PR DESCRIPTION
### Fixed

- Fixing the `OnNextResult` generic definition. It didn't include the generic parameter properly and forcing one to have to cast the result to `QueryResult<TDataType>`. Now it will be correct data type.
