### PR TITLE
Adding delete to the filter of things we watch for Mongo

### DIFF
--- a/Source/DotNET/CQRS.MongoDB/MongoDBCollectionExtensions.cs
+++ b/Source/DotNET/CQRS.MongoDB/MongoDBCollectionExtensions.cs
@@ -156,7 +156,7 @@ public static class MongoDBCollectionExtensions
             filterRendered,
             Builders<ChangeStreamDocument<TDocument>>.Filter.In(
                 new StringFieldDefinition<ChangeStreamDocument<TDocument>, string>("operationType"),
-                new[] { "insert", "replace", "update" }));
+                new[] { "insert", "replace", "update", "delete" }));
 
         var pipeline = new EmptyPipelineDefinition<ChangeStreamDocument<TDocument>>().Match(fullFilter);
 


### PR DESCRIPTION
### Fixed

- Adding `delete` to the change stream filter for `.Observer()` on Mongo collections.
