### PR TITLE
Exception handling for JSON serializer + outputting error to console if any

### DIFF
--- a/Source/DotNET/CQRS/Queries/ClientObservable.cs
+++ b/Source/DotNET/CQRS/Queries/ClientObservable.cs
@@ -51,15 +51,16 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         subscription = _subject.Subscribe(async _ =>
         {
             queryResult.Data = _!;
-            var message = JsonSerializer.SerializeToUtf8Bytes(queryResult, jsonOptions.JsonSerializerOptions);
 
             try
             {
+                var message = JsonSerializer.SerializeToUtf8Bytes(queryResult, jsonOptions.JsonSerializerOptions);
                 await webSocket.SendAsync(message, WebSocketMessageType.Text, true, CancellationToken.None);
                 message = null!;
             }
-            catch
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"Error sending message to client: {ex.Message}\n{ex.StackTrace}");
                 subscription?.Dispose();
                 ClientDisconnected?.Invoke();
             }


### PR DESCRIPTION
### Fixed

- Handling exceptions if serialization to UTF8 for the WebSocket connections.
- Printing any exceptions that occur during serialization or sending data to client over WebSockets.
