### PR TITLE
 "Add version v1.5.6 to changelog"

### DIFF
--- a/Source/DotNET/CQRS.MongoDB/MongoDBCollectionExtensions.cs
+++ b/Source/DotNET/CQRS.MongoDB/MongoDBCollectionExtensions.cs
@@ -203,9 +203,9 @@ public static class MongoDBCollectionExtensions
                             }
                         }
                     }
-                }
 
-                onNext(documents, observable);
+                    onNext(documents, observable);
+                }
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
### Fixed

- `OnNext()` was never called on the observable given to the `MongoDBCollectionExtensions` when observing changes for `ClientObservables`.
