### PR TITLE
Fix/cancellable-queries

### DIFF
--- a/Source/DotNET/CQRS/Queries/ClientObservable.cs
+++ b/Source/DotNET/CQRS/Queries/ClientObservable.cs
@@ -47,6 +47,7 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         using var webSocket = await context.HttpContext.WebSockets.AcceptWebSocketAsync();
         IDisposable? subscription = default;
         var queryResult = new QueryResult();
+        var cts = new CancellationTokenSource();
 
         subscription = _subject.Subscribe(async _ =>
         {
@@ -55,7 +56,7 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
             try
             {
                 var message = JsonSerializer.SerializeToUtf8Bytes(queryResult, jsonOptions.JsonSerializerOptions);
-                await webSocket.SendAsync(message, WebSocketMessageType.Text, true, CancellationToken.None);
+                await webSocket.SendAsync(message, WebSocketMessageType.Text, true, cts.Token);
                 message = null!;
             }
             catch (Exception ex)
@@ -69,14 +70,14 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         var buffer = new byte[1024 * 4];
         try
         {
-            var received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            var received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
 
             while (!received.CloseStatus.HasValue)
             {
-                received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
             }
 
-            await webSocket.CloseAsync(received.CloseStatus.Value, received.CloseStatusDescription, CancellationToken.None);
+            await webSocket.CloseAsync(received.CloseStatus.Value, received.CloseStatusDescription, cts.Token);
         }
         catch
         {
@@ -84,6 +85,8 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         }
         finally
         {
+            cts.Cancel();
+            _subject.OnCompleted();
             subscription?.Dispose();
             ClientDisconnected?.Invoke();
         }

--- a/Source/DotNET/CQRS/Queries/ClientObservable.cs
+++ b/Source/DotNET/CQRS/Queries/ClientObservable.cs
@@ -47,7 +47,7 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         using var webSocket = await context.HttpContext.WebSockets.AcceptWebSocketAsync();
         IDisposable? subscription = default;
         var queryResult = new QueryResult();
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         subscription = _subject.Subscribe(async _ =>
         {

--- a/Source/JavaScript/Applications/queries/QueryFor.ts
+++ b/Source/JavaScript/Applications/queries/QueryFor.ts
@@ -16,6 +16,8 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
     abstract readonly routeTemplate: Handlebars.TemplateDelegate;
     abstract get requestArguments(): string[];
     abstract defaultValue: TDataType;
+    abortController?: AbortController;
+
 
     /**
      * Initializes a new instance of the {@link ObservableQueryFor<,>}} class.
@@ -36,13 +38,20 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
             });
         }
 
+        if (this.abortController) {
+            this.abortController.abort();
+        }
+
+        this.abortController = new AbortController();
+
         actualRoute = this.routeTemplate(args);
         const response = await fetch(actualRoute, {
             method: 'GET',
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json'
-            }
+            },
+            signal: this.abortController.signal
         });
 
         try {


### PR DESCRIPTION
### Fixed

- Fixing so that if a client fetches from the same query multiple times and the response could potentialle come out of order, we make sure to cancel any ongoing requests.
- Adding a cancellation token for `ObservableClient` queries that we pass along to every WebSocket operation in case the client disconnects.
