### PR TITLE
Remove enumerable for observable query

### DIFF
--- a/Source/DotNET/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -53,24 +53,12 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
     }
 
 {{#if Arguments.[0]}}
-{{#if IsEnumerable}}
-    static use(args?: {{Name}}Arguments): [ObservableQueryResult<{{Model}}[]>] {
-        return useObservableQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args);
-    }
-{{else}}
     static use(args?: {{Name}}Arguments): [ObservableQueryResult<{{Model}}>] {
         return useObservableQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
-    }
-{{/if}}
-{{else}}
-{{#if IsEnumerable}}
-    static use(): [ObservableQueryResult<{{Model}}[]>] {
-        return useObservableQuery<{{Model}}[], {{Name}}>({{Name}});
     }
 {{else}}
     static use(): [ObservableQueryResult<{{Model}}>] {
         return useObservableQuery<{{Model}}, {{Name}}>({{Name}});
     }
-{{/if}}
 {{/if}}
 }


### PR DESCRIPTION
useObservableQuery now always returns an object, never an enumerable.