### PR TITLE
Actually remove the Array return for useObservableQuery

### DIFF
--- a/Source/DotNET/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -53,11 +53,11 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
     }
 
 {{#if Arguments.[0]}}
-    static use(args?: {{Name}}Arguments): [ObservableQueryResult<{{Model}}>] {
+    static use(args?: {{Name}}Arguments): ObservableQueryResult<{{Model}}> {
         return useObservableQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
     }
 {{else}}
-    static use(): [ObservableQueryResult<{{Model}}>] {
+    static use(): ObservableQueryResult<{{Model}}> {
         return useObservableQuery<{{Model}}, {{Name}}>({{Name}});
     }
 {{/if}}


### PR DESCRIPTION
Didn't remove the Array, only the branching part.